### PR TITLE
feat: add simple prettier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ module.exports = {
 }
 ```
 
-And run with:
+To add `prettier` to tour `eslint` workflow, just install:
+
+```sh
+yarn add -D prettier
+```
+
+And point `prettier` to the shared configuration in `package.json`:
+
+```json
+  "prettier": "@typeform/eslint-config/prettier"
+```
+
+Now run `eslint` with:
 
 ```sh
 yarn eslint . --fix

--- a/index.js
+++ b/index.js
@@ -1,34 +1,29 @@
 const a11yLintRules = require('./accessibility/lint-rules')
 const performanceRules = require('./performance/lint-rules')
 
-module.exports = {
+const config = {
   parser: 'babel-eslint',
   extends: [
+    './with-prettier.js',
     'standard',
     'standard-jsx',
+    'plugin:import/errors',
     'plugin:react/recommended',
     'prettier/react',
     'prettier/standard',
   ],
-  plugins: [
-    'filenames',
-    'jsx-a11y',
-    'react',
-    'react-perf',
-    'react-hooks',
-    'jest',
-  ],
+  plugins: ['filenames', 'jsx-a11y', 'react', 'react-perf', 'react-hooks', 'jest'],
   settings: {
     react: {
       version: '16',
     },
   },
   env: {
-    browser: true,
-    commonjs: true,
-    es6: true,
-    jest: true,
-    node: true,
+    'browser': true,
+    'commonjs': true,
+    'es6': true,
+    'jest': true,
+    'node': true,
     'jest/globals': true,
   },
   parserOptions: {
@@ -79,7 +74,7 @@ module.exports = {
     'filenames/match-regex': ['warn', '^_?[a-z0-9-.]+$'],
     'jest/no-focused-tests': 'error',
     'comma-dangle': ['error', 'always-multiline'],
-    complexity: ['warn', { max: 7 }],
+    'complexity': ['warn', { max: 7 }],
     'consistent-return': 'warn',
     'global-require': 'warn',
     'no-console': 'warn',
@@ -92,3 +87,5 @@ module.exports = {
     'prefer-template': 'warn',
   }),
 }
+
+module.exports = config

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
-const a11yLintRules = require('./accessibility/lint-rules')
-const performanceRules = require('./performance/lint-rules')
+const a11yLintRules = require('./accessibility/lint-rules');
+const performanceRules = require('./performance/lint-rules');
 
 const config = {
   parser: 'babel-eslint',
   extends: [
     './with-prettier.js',
-    'standard',
-    'standard-jsx',
     'plugin:import/errors',
     'plugin:react/recommended',
     'prettier/react',
@@ -86,6 +84,6 @@ const config = {
     'prefer-const': 'warn',
     'prefer-template': 'warn',
   }),
-}
+};
 
-module.exports = config
+module.exports = config;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-const a11yLintRules = require('./accessibility/lint-rules');
-const performanceRules = require('./performance/lint-rules');
+const a11yLintRules = require('./accessibility/lint-rules')
+const performanceRules = require('./performance/lint-rules')
 
 const config = {
   parser: 'babel-eslint',
   extends: [
     './with-prettier.js',
+    'standard',
+    'standard-jsx',
     'plugin:import/errors',
     'plugin:react/recommended',
     'prettier/react',
@@ -84,6 +86,6 @@ const config = {
     'prefer-const': 'warn',
     'prefer-template': 'warn',
   }),
-};
+}
 
-module.exports = config;
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "access": "restricted"
   },
   "dependencies": {
-    "eslint-config-prettier": "^3.1.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-config-standard": "^12.0.0",
     "eslint-config-standard-jsx": "^6.0.2",
     "eslint-plugin-filenames": "^1.3.2",
@@ -36,6 +36,7 @@
     "eslint-plugin-jest": "^22.6.4",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-react-hooks": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "dependencies": {
     "eslint-config-prettier": "^6.10.1",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-config-standard-jsx": "^6.0.2",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^22.6.4",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
   },
   "dependencies": {
     "eslint-config-prettier": "^6.10.1",
-    "eslint-config-standard": "^12.0.0",
-    "eslint-config-standard-jsx": "^6.0.2",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^22.6.4",

--- a/prettier.js
+++ b/prettier.js
@@ -1,0 +1,13 @@
+module.exports = {
+  printWidth: 120,
+  tabWidth: 2,
+  useTabs: false,
+  semi: false,
+  singleQuote: true,
+  quoteProps: 'as-needed',
+  jsxSingleQuote: false,
+  trailingComma: 'es5',
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  arrowParens: 'always',
+}

--- a/with-prettier.js
+++ b/with-prettier.js
@@ -1,4 +1,6 @@
-let config = {}
+let config = {
+  extends: ['standard', 'standard-jsx'],
+}
 
 try {
   require('prettier')

--- a/with-prettier.js
+++ b/with-prettier.js
@@ -1,0 +1,15 @@
+let config = {}
+
+try {
+  require('prettier')
+
+  config = {
+    plugins: ['prettier'],
+    extends: ['plugin:prettier/recommended'],
+    rules: {
+      'prettier/prettier': 'error',
+    },
+  }
+} catch (err) {}
+
+module.exports = config

--- a/with-prettier.js
+++ b/with-prettier.js
@@ -1,6 +1,4 @@
-let config = {
-  extends: ['standard', 'standard-jsx'],
-}
+let config = {}
 
 try {
   require('prettier')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,16 +2179,6 @@ eslint-config-prettier@^6.10.1:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-standard-jsx@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz#90c9aa16ac2c4f8970c13fc7efc608bacd02da70"
-  integrity sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==
-
-eslint-config-standard@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
-  integrity sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==
-
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,6 +2179,16 @@ eslint-config-prettier@^6.10.1:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-config-standard-jsx@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz#90c9aa16ac2c4f8970c13fc7efc608bacd02da70"
+  integrity sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==
+
+eslint-config-standard@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
+  integrity sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,10 +2172,10 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz#41afc8d3b852e757f06274ed6c44ca16f939a57d"
-  integrity sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==
+eslint-config-prettier@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz#129ef9ec575d5ddc0e269667bf09defcd898642a"
+  integrity sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -2269,6 +2269,13 @@ eslint-plugin-node@^8.0.0:
     minimatch "^3.0.4"
     resolve "^1.8.1"
     semver "^5.5.0"
+
+eslint-plugin-prettier@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz#ae116a0fc0e598fdae48743a4430903de5b4e6ca"
+  integrity sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-promise@^4.0.1:
   version "4.0.1"
@@ -2519,6 +2526,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.4"
@@ -5260,6 +5272,13 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
This PR adds prettier eslint integration.

Next steps:

- [ ] agree on basic rules
  - [ ] [printWidth](https://prettier.io/docs/en/options.html#print-width) (default: 80)
  - [ ] [tabWidth](https://prettier.io/docs/en/options.html#tab-width) (default: 2)
  - [ ] [Print semicolons at the ends of statements.](https://prettier.io/docs/en/options.html#semicolons) (default: true)
  - [ ] [singleQuote](https://prettier.io/docs/en/options.html#quotes) (default: false)
  - [ ] [quoteProps](https://prettier.io/docs/en/options.html#quote-props) (default: "as-needed")
  - [ ] [jsxSingleQuote](https://prettier.io/docs/en/options.html#jsx-quotes) (default: false)
  - [ ] [trailingComma](https://prettier.io/docs/en/options.html#trailing-commas) (default: "es5")
  - [ ] [bracketSpacing](https://prettier.io/docs/en/options.html#bracket-spacing) (default: true)
  - [ ] [jsxBracketSameLine](https://prettier.io/docs/en/options.html#jsx-brackets) (default: false)
  - [ ] [arrowParens](https://prettier.io/docs/en/options.html#arrow-function-parentheses) (default: "always")
- [ ] release under `@next`
- [ ] try out in few repos with and without prettier installed