### PR TITLE
Use common travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+version: ~> 1.0
+import: Typeform/travis-shared-config:package-config.yml@master
+
 language: node_js
 node_js:
   - '10'
@@ -12,7 +15,7 @@ script:
   - yarn run lint
 
 after_success:
-  - yarn run travis-deploy-once "npm run semantic-release"
+  - yarn run travis-deploy-once "yarn run semantic-release"
 
 notifications:
   email: false


### PR DESCRIPTION
Imports a shared travis configuration for the package. This shared travis configuration can be used to perform CI tasks common to all Typeform node libraries. We will use it as part of the NPM to GitHub package migration process.