### PR TITLE
feat: use prettier for formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: node_js
 node_js:
   - '12'
 
-# Travis runs on PUSH events ONLY in master branch. This does not affect to Travis running on PULL REQUEST event
+# Travis runs on PUSH events ONLY in the following branches. This does not affect to Travis running on PULL REQUEST event
 branches:
   only:
     - master
+    - next
 
 cache: yarn
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ module.exports = {
     'prefer-template': 'warn',
     'react/prop-types': 'error',
     'react-hooks/exhaustive-deps': 'error',
-    'comma-dangle': ['error', 'always-multiline'],
   },
   settings: {
     react: {

--- a/index.js
+++ b/index.js
@@ -6,9 +6,6 @@ module.exports = {
     'prettier/@typescript-eslint',
     'prettier/babel',
     'prettier/react',
-    'prettier/standard',
-    'standard',
-    'standard-jsx',
   ],
   plugins: ['jest'],
   env: {

--- a/package.json
+++ b/package.json
@@ -21,14 +21,13 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "yarn run eslint --fix",
-      "git add"
-    ]
+    "*.js": "yarn run eslint --fix",
+    "*.{js,css,md}": "prettier --write"
   },
   "publishConfig": {
     "access": "public"
   },
+  "prettier": "./prettier",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
@@ -45,8 +44,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-standard": "^5.0.0"
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "peerDependencies": {
     "@babel/core": "7.x",
@@ -58,6 +56,7 @@
     "eslint": "^7.14.0",
     "husky": "^4.3.0",
     "lint-staged": "^10.5.2",
+    "prettier": "^2.2.1",
     "semantic-release": "^17.3.0"
   },
   "release": {

--- a/prettier/index.js
+++ b/prettier/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,11 +1886,6 @@ eslint-plugin-react@^7.21.5:
     resolve "^1.18.1"
     string.prototype.matchall "^4.0.2"
 
-eslint-plugin-standard@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz#c43f6925d669f177db46f095ea30be95476b1ee4"
-  integrity sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==
-
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -4462,6 +4457,11 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
- Drops usage of standard-js
- Adds default prettier config for typeform org
- Updates lint-staged steps

BREAKING CHANGE: removes standard-js packages, which will affect
formatting and possibly other rules