### PR TITLE
fix(prettier): add quoteProps="consistent" to go along with eslint

### DIFF
--- a/prettier/index.js
+++ b/prettier/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   semi: false,
   singleQuote: true,
+  quoteProps: 'consistent',
 }


### PR DESCRIPTION
Adds prettier rule for [quoteProps](https://prettier.io/docs/en/options.html#quote-props) to avoid similar eslint rule violation

![image](https://user-images.githubusercontent.com/13509022/102501991-5b7e6880-407e-11eb-98e4-ec8cba270f4b.png)

![image](https://user-images.githubusercontent.com/13509022/102501976-55888780-407e-11eb-89dc-553145f83cf3.png)


