### PR TITLE
chore(fear-575): tweak to github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   main:
     name: Run checks and deploy
-    runs-on: [self-hosted, fear]
+    runs-on: [ubuntu-latest]
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
The repo is public, so the runners `self-hosted, fear` aren't exposed to it and the action fail to run
Changed for ubuntu runner