### PR TITLE
fix(FEAR-1231): turn off eslint no-extra-semi rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ module.exports = {
   ],
   plugins: ['jest'],
   env: {
-    browser: true,
-    commonjs: true,
-    es6: true,
-    jest: true,
-    node: true,
+    'browser': true,
+    'commonjs': true,
+    'es6': true,
+    'jest': true,
+    'node': true,
     'jest/globals': true,
   },
   parserOptions: {
@@ -22,6 +22,7 @@ module.exports = {
     },
   },
   rules: {
+    '@typescript-eslint/no-extra-semi': 'off',
     'import/order': [
       'warn',
       {


### PR DESCRIPTION
This rule can conflict with Prettier, generating a tug-of-war between the two.
As Prettier is now required in our repos and in charge of the semi-colons, this rule can be deactivated 