### PR TITLE
feat(CRT-1281): add '@typescript-eslint/no-explicit-any' warn rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
     'prefer-template': 'warn',
     'react/prop-types': 'error',
     'react-hooks/exhaustive-deps': 'error',
+    '@typescript-eslint/no-explicit-any': 'warn',
     'no-restricted-imports': [
       'warn',
       {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "peerDependencies": {
     "@babel/core": "7.x",
-    "eslint": ">=7.27.x"
+    "eslint": ">=7.27.x",
+    "typescript": ">=4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -57,7 +58,8 @@
     "husky": "^4.3.0",
     "lint-staged": "^10.5.2",
     "prettier": "^2.2.1",
-    "semantic-release": "^17.3.0"
+    "semantic-release": "^17.3.0",
+    "typescript": "^4.7.2"
   },
   "release": {
     "branches": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5809,6 +5809,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+
 uglify-js@^3.1.4:
   version "3.14.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.3.tgz#c0f25dfea1e8e5323eccf59610be08b6043c15cf"


### PR DESCRIPTION
## Description

This PR implements the Standard Proposal to forbid explicit "any" type in Typescript.
For more information: [proposal](https://www.notion.so/typeform/Forbid-explicit-type-any-in-Typescript-a2232b58fc1e455d97505a6199a067db)
For more details about this lint rule: [@typescript-eslint/no-explicit-any](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-explicit-any.md)

This PR enables this rule with `warn` level, and should stay this way for a quarter, giving enough time to everyone fix their repositories. After that period we should change it to `error`. 

## BREAKING CHANGE

In order to make `@typescript-eslint/no-explicit-any` rule work we had to add `typescript` as a peer dependency.