### PR TITLE
fix(WEB-4636): Upgrade eslint-plugin-promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'react-app',
     'plugin:jsx-a11y/recommended',
+    'plugin:promise/recommended',
     'prettier',
     'prettier/@typescript-eslint',
     'prettier/babel',
@@ -25,6 +26,11 @@ module.exports = {
     'no-var': 'warn',
     'curly': 'warn',
     'prefer-destructuring': 'warn',
+    'promise/always-return': 'warn',
+    'promise/no-return-wrap': 'warn',
+    'promise/param-names': 'warn',
+    'promise/catch-or-return': 'warn',
+    'promise/no-new-statics': 'warn',
     '@typescript-eslint/no-extra-semi': 'off',
     'import/order': [
       'warn',

--- a/index.test.js
+++ b/index.test.js
@@ -58,6 +58,30 @@ describe('eslint config', () => {
     expect(output.includes('"errorCount":0')).toBeTruthy()
     expect(output.includes('"warningCount":1')).toBeTruthy()
   })
+
+  it('should warn if promise does not return', () => {
+    const output = child_process
+      .execSync(
+        'yarn eslint -f "json" --no-ignore test-cases/warn-promise-always-return.js'
+      )
+      .toString()
+
+    expect(output.includes('"ruleId":"promise/always-return"')).toBeTruthy()
+    expect(output.includes('"errorCount":0')).toBeTruthy()
+    expect(output.includes('"warningCount":1')).toBeTruthy()
+  })
+
+  it('should warn if promises are nested', () => {
+    const output = child_process
+      .execSync(
+        'yarn eslint -f "json" --no-ignore test-cases/warn-promise-no-nesting.js'
+      )
+      .toString()
+
+    expect(output.includes('"ruleId":"promise/no-nesting"')).toBeTruthy()
+    expect(output.includes('"errorCount":0')).toBeTruthy()
+    expect(output.includes('"warningCount":1')).toBeTruthy()
+  })
   // #endregion
 
   // #region Fail

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0"
   },

--- a/test-cases/pass.js
+++ b/test-cases/pass.js
@@ -5,4 +5,12 @@ if (true) {
   const { a } = data
   myVariable += a + data.b
 }
-return myVariable
+
+const doAsyncStuff = (variable) =>
+  new Promise(() => {
+    return variable + 12
+  }).then((result) => {
+    return result * 2
+  })
+
+return doAsyncStuff(myVariable)

--- a/test-cases/warn-promise-always-return.js
+++ b/test-cases/warn-promise-always-return.js
@@ -1,0 +1,14 @@
+const log = () => null
+
+const doAsyncStuff = () =>
+  new Promise(() => {
+    return 12
+  })
+    .then((result) => {
+      log(result)
+    })
+    .catch((err) => {
+      throw err
+    })
+
+return doAsyncStuff

--- a/test-cases/warn-promise-no-nesting.js
+++ b/test-cases/warn-promise-no-nesting.js
@@ -1,0 +1,14 @@
+const doAsyncStuff = () =>
+  new Promise(() => {
+    return 12
+  })
+    .then((result) => {
+      return new Promise().then(() => {
+        return result * 2
+      })
+    })
+    .catch((err) => {
+      throw err
+    })
+
+return doAsyncStuff

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,10 +2777,10 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-promise@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
-  integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
+eslint-plugin-promise@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz#017652c07c9816413a41e11c30adc42c3d55ff18"
+  integrity sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==
 
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
WEB-4636

https://www.npmjs.com/package/eslint-plugin-promise

https://www.notion.so/typeform/Recent-eslint-config-typeform-changes-41aa296dc0d545c5bd5e3507d20295e4

Short summary
---
Upgrading `esling-plugin-promise` and adding the default set of rules.

## Things to include:

- [x] Description of what's changed and why it will help
- [x] Updated test pass case
- [x] Added test fail case
