### PR TITLE
feat(FEAR-3344): Add jsx key rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = {
     'prefer-template': 'warn',
     'react/prop-types': 'error',
     'react-hooks/exhaustive-deps': 'error',
+    'react/jsx-key': ['warn', { checkFragmentShorthand: true }],
     '@typescript-eslint/no-explicit-any': 'warn',
     'no-restricted-imports': [
       'warn',


### PR DESCRIPTION
Recent changes in Babel runtime mode in [babel-preset-typeform](https://github.com/Typeform/babel-preset-typeform/pull/29/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R3) force the presence of `keys` in enumeration in jsx, *in development environment only*.
Missing keys will cause the application to blow up, with sometimes cryptic error.

Adding this rule, that enforces keys, will help prevent this error/ detect what places are missing keys.

![CleanShot 2022-08-26 at 16 40 52](https://user-images.githubusercontent.com/6507291/186930289-699794fa-9e92-434e-944d-05d51fbc41b6.png)
