### PR TITLE
chore(WEB-5967): Bump deploy node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Set GitHub packages registry
         run: |


### PR DESCRIPTION
WEB-5967

Short summary
---

Bumps the node version used by the deploy github action

## Things to include:

- [ ] Description of what's changed and why it will help
- [ ] Updated test pass case
- [ ] Added test fail case
