### PR TITLE
fix(REACH-458): Release to both Github and NPM registries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,4 @@ jobs:
         run: yarn semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
[JIRA ticket REACH-458](https://typeform.atlassian.net/browse/REACH-458)

When migrating from Travis to Github Actions https://github.com/Typeform/eslint-config-typeform/pull/32 the original functionality to release to both registries was lost https://github.com/Typeform/eslint-config-typeform/pull/9. Re-adding the `NPM_TOKEN` to the action step should fix this.

We need to release this repo as public package to npmjs.com because it is used by our open-source library [@typeform/embed](https://github.com/Typeform/embed).

Note: `NPM_TOKEN` secret needs to be available for this repo.