### PR TITLE
fix(REACH-458): Release alpha and beta versions from respective branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - next
+      - alpha
+      - beta
 
 jobs:
   main:


### PR DESCRIPTION
To test releasing to both registries - Github and NPM.