### PR TITLE
fix(REACH-458): Update command for npmjs registry release

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest",
     "eslint": "eslint",
     "lint": "yarn run eslint .",
-    "publish:github": "npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN && npm publish --registry https://npm.pkg.github.com"
+    "publish:npm": "npm config set @typeform:registry https://registry.npmjs.org/ && npm config set '//registry.npmjs.org/:_authToken' $NPM_TOKEN && npm publish"
   },
   "husky": {
     "hooks": {
@@ -85,7 +85,7 @@
       [
         "@semantic-release/exec",
         {
-          "successCmd": "yarn run publish:github"
+          "successCmd": "yarn run publish:npm"
         }
       ]
     ]


### PR DESCRIPTION
[JIRA ticket](https://typeform.atlassian.net/browse/REACH-458)

We were able to [successfully release alpha version](https://github.com/Typeform/eslint-config-typeform/actions/runs/5346401246/jobs/9693378587) to both Github and NPM registries.

When we merge this, we should be able to release production version to both.

We need to release this repo as public package to npmjs.com because it is used by our open-source library [@typeform/embed](https://github.com/Typeform/embed).