### PR TITLE
feat(NOJIRA-1234): added warning for type imports and exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,13 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'error',
     'react/jsx-key': ['warn', { checkFragmentShorthand: true }],
     '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'inline-type-imports',
+      },
+    ],
     'no-restricted-imports': [
       'warn',
       {


### PR DESCRIPTION
[Consistent type imports](https://typescript-eslint.io/rules/consistent-type-imports/#:~:text=Enforce%20consistent%20usage%20of%20type%20imports.&text=Some%20problems%20reported%20by%20this,type%20system%2C%20not%20at%20runtime)

Short summary
---

With this rule, we're making it obvious which imports/exports are only used for types and keeping the compiled JS a bit cleaner by stripping out type-only code, helping a bit with bundle size. Might also help us avoid subtle circular dependency issues.

## Things to include:

- [X] Description of what's changed and why it will help
- [ ] Updated test pass case
- [ ] Added test fail case
