### PR TITLE
Fix CI Standard Checks timeout due to runner restrictions

### DIFF
--- a/.github/workflows/ci-standard-checks.yml
+++ b/.github/workflows/ci-standard-checks.yml
@@ -15,3 +15,5 @@ on:
 jobs:
   ci-standard-checks:
     uses: Typeform/.github/.github/workflows/ci-standard-checks-workflow.yaml@v1
+    with:
+      runner: ubuntu-latest


### PR DESCRIPTION
## Fix CI Standard Checks timeout due to runner restrictions

### Problem
CI Standard Checks workflow has been timing out after 24 hours since March 27. The reusable workflow defaults to `ci-base-scale-set` (self-hosted runners), but these are restricted to private repos. Public repos like `eslint-config-typeform` can't access them, causing jobs to queue indefinitely until auto-cancelled.

### Solution
Override the runner parameter to explicitly use `ubuntu-latest` (GitHub-hosted runners).

### Changes
- Updated `.github/workflows/ci-standard-checks.yml` to specify `runner: ubuntu-latest`

### Impact
- CI builds will now start immediately instead of timing out after 24 hours
- Workflows will run on GitHub-hosted runners as intended for public repositories

Fixes: https://github.com/Typeform/eslint-config-typeform/actions/runs/23994588338