### PR TITLE
chore: align dependabot config with Typeform standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,53 @@
 version: 2
 
-updates:
-- package-ecosystem: npm
-  schedule:
-    interval: weekly
-    day: sunday
-  groups:
-    dependencies:
-      patterns:
-        - "*"
-  directories:
-    - "/"
-  commit-message:
-    prefix: fix(dependabot)
-  ignore:
-    # eslint v10 removes context.getFilename() which eslint-plugin-react v7.x
-    # still relies on, causing "contextOrFilename.getFilename is not a function".
-    # Stay on eslint v9.x until eslint-plugin-react ships a compatible release.
-    - dependency-name: "eslint"
-      versions: [">=10"]
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.GH_TOKEN }}
+  git-github:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: '${{ secrets.GH_TOKEN }}'
 
-- package-ecosystem: github-actions
-  schedule:
-    interval: weekly
-    day: sunday
-  groups:
-    dependencies:
-      patterns:
-        - "*"
-  directory: "/"
-  commit-message:
-    prefix: build(dependabot)
+updates:
+  - package-ecosystem: npm
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+    directories:
+      - "/"
+    commit-message:
+      prefix: fix(dependabot)
+    registries:
+      - npm-github
+      - git-github
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@typeform/*"
+    ignore:
+      # eslint v10 removes context.getFilename() which eslint-plugin-react v7.x
+      # still relies on, causing "contextOrFilename.getFilename is not a function".
+      # Stay on eslint v9.x until eslint-plugin-react ships a compatible release.
+      - dependency-name: "eslint"
+        versions: [">=10"]
+
+  - package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+    directory: "/"
+    commit-message:
+      prefix: build(dependabot)
+    registries:
+      - git-github


### PR DESCRIPTION
## Summary

Aligns `.github/dependabot.yml` with the [Typeform canonical standard](https://www.notion.so/typeform/Keeping-dependencies-updated-10c23dfc4c008038b02bebcb88de6867).

Specific changes are described in the diff — typical fixes include adding the `cooldown` block for npm, fixing commit-message prefixes (`ci(dependabot)` → `fix(dependabot)`, `fix(dependabot)` → `build(dependabot)` for github-actions), and adding required `registries` blocks.

## Test plan

- [ ] Merge and wait for the next Sunday Dependabot run
- [ ] Verify grouped PRs continue to open on schedule
- [ ] Confirm commit messages use the corrected prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
